### PR TITLE
pxx-4 remove sys.exit from parse method

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: mluis7
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+DO NOT post XML samples as images, please. It's a bad practice and I won't type the sample for you
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Linux, Windows]
+
+**Additional context**
+Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 # pyxml2xpath
 Parse XML document and build XPath expression corresponding to its structure.
 
+<h3> &#x24D8; Project status: BETA </h3>
+
 ## Description
 Found XPath expressions are tested against the document and the count of found elements is returned. See also `parse()` method below.
 

--- a/src/xml2xpath/xml2xpath.py
+++ b/src/xml2xpath/xml2xpath.py
@@ -4,6 +4,7 @@ import sys
 import os.path
 from lxml import etree
 from typing import Dict, Tuple
+import errno
 
 def get_qname(qname, revns):
     '''Get qualified name'''
@@ -206,10 +207,10 @@ def parse(file: str, *, itree: etree._ElementTree = None, xpath_base: str = '//*
         tree = itree
         if tree is None:
             if not os.path.isfile(file):
-                sys.exit("ERROR: File not found")
-            
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), file)
             with open(file, "r") as fin:
                 tree = etree.parse(fin)
+        
         nsmap = build_namespace_dict(tree)
         #print(f"Namespaces found: {nsmap}")
         xmap = parse_mixed_ns(tree, nsmap, xpath_base)
@@ -217,7 +218,6 @@ def parse(file: str, *, itree: etree._ElementTree = None, xpath_base: str = '//*
     except Exception as e:
         print("ERROR.", type(e).__name__, "–", e)
         raise(e)
-        sys.exit(f"Error parsing {file}\n")
 
 def main():
     file = sys.argv[1]


### PR DESCRIPTION
Throws ugly stack traces on file not found or lxml parse exception.
Added new issue template and small README additions.